### PR TITLE
stronger type hint

### DIFF
--- a/python/llguidance/_lib.pyi
+++ b/python/llguidance/_lib.pyi
@@ -1,5 +1,5 @@
 from typing import List, Tuple, Mapping, Optional, Sequence, Union
-from ._util import TokenId
+from ._util import TokenId, StopReason
 from ._tokenizer import TokenizerWrapper
 
 
@@ -86,7 +86,7 @@ class LLInterpreter:
         of the parser.
         """
 
-    def stop_reason(self) -> str:
+    def stop_reason(self) -> StopReason:
         """
         Get the reason why the parser stopped.
         Returns:

--- a/python/llguidance/_util.py
+++ b/python/llguidance/_util.py
@@ -1,1 +1,4 @@
+from typing import Literal
+
 TokenId = int
+StopReason = Literal["NotStopped", "MaxTokensTotal", "MaxTokensParser", "ParserNotAccepting", "NoExtension", "NoExtensionBias", "EndOfSentence", "InternalError"]


### PR DESCRIPTION
Teeny tiny little PR. Make the return type of `stop_reason` a bit narrower (one of an enum of strings rather than just any old string)